### PR TITLE
Converting Integer to Float is allowed

### DIFF
--- a/src/jsonconfig/cast.hpp
+++ b/src/jsonconfig/cast.hpp
@@ -10,6 +10,7 @@
 #include <pficommon/lang/shared_ptr.h>
 
 #include "config.hpp"
+#include "exception.hpp"
 
 namespace jsonconfig {
 
@@ -65,6 +66,11 @@ inline bool check_json_type(
     json_config_iarchive_cast& js,
     pfi::text::json::json::json_type_t t) {
   if (js.get().type() != t) {
+    // int -> float is valid
+    if (js.get().type() == pfi::text::json::json::Integer &&
+        t == pfi::text::json::json::Float) {
+      return true;
+    }
     type_error e(js.get_config().path(), t, js.get().type());
     if (js.trace_error()) {
       js.push_error(e);

--- a/src/jsonconfig_test.cpp
+++ b/src/jsonconfig_test.cpp
@@ -404,4 +404,29 @@ TEST(jsonconfig_cast, error) {
   EXPECT_EQ(json::Integer, e3->actual());
 }
 
+struct float_values {
+  template <class Ar>
+  void serialize(Ar& ar) {
+    ar
+        & MEMBER(float1)
+        & MEMBER(float2)
+        & MEMBER(double1)
+        & MEMBER(double2);
+  }
+  float float1, float2;
+  double double1, double2;
+};
+
+TEST(jconconfig_cast, int_to_float) {
+  config_root j(lexical_cast<json>(
+      "{\"float1\": 0, \"float2\": 1, \"double1\": 0, \"double2\": -1}"));
+  ASSERT_NO_THROW(config_cast<float_values>(j));
+  float_values fvs = config_cast<float_values>(j);
+
+  EXPECT_EQ(0, fvs.float1);
+  EXPECT_EQ(1, fvs.float2);
+  EXPECT_EQ(0, fvs.double1);
+  EXPECT_EQ(-1, fvs.double2);
+}
+
 }  // namespace jsonconfig


### PR DESCRIPTION
Current type checking does not allow to convert integer values in JSON to float/double. So you need to write like "0.0" to JSON files for Float fields, and that is inconvinience.
This PR changes type checking to allow converting Integer to Float.